### PR TITLE
Command Line Interface and Small Changes

### DIFF
--- a/indicator-stickynotes.py
+++ b/indicator-stickynotes.py
@@ -258,7 +258,6 @@ def handler(indicator):
 
 def reload_handler(indicator):
     # reload from data file on SIGUSR2
-    indicator.nset.save()
     with open(os.path.expanduser(indicator.data_file), encoding="utf-8") as fsock:
         indicator.nset.merge(fsock.read())
     install_glib_handler(indicator, signal.SIGUSR2)
@@ -355,7 +354,7 @@ if __name__ == "__main__":
                 else stickynotes.info.SETTINGS_FILE)
         try: noteset.open()
         except Exception as e:
-            print('fialed to load config file')
+            print('failed to load config file')
             sys.exit(1)
         notebody = ' '.join(args.new).encode().decode('unicode-escape')     \
             .encode('latin1').decode('utf-8') if args.new                   \
@@ -364,9 +363,12 @@ if __name__ == "__main__":
         noteset.save()
 
     pid = is_running()
-    if pid: # send signal to the existing process accordingly
-        os.kill(pid, (args.kill and signal.SIGKILL) or (args.refresh and    \
-            signal.SIGUSR2) or signal.SIGUSR1)
+    if pid:
+        if   args.kill:     sig = signal.SIGKILL
+        elif args.refresh:  sig = signal.SIGUSR2
+        else:               sig = signal.SIGUSR1
+        # send signal to the existing process accordingly
+        os.kill(pid, sig)
     elif not (args.kill or args.refresh):
         main()   # run
 

--- a/indicator-stickynotes.py
+++ b/indicator-stickynotes.py
@@ -258,6 +258,7 @@ def handler(indicator):
 
 def reload_handler(indicator):
     # reload from data file on SIGUSR2
+    indicator.nset.save()
     with open(os.path.expanduser(indicator.data_file), encoding="utf-8") as fsock:
         indicator.nset.merge(fsock.read())
     install_glib_handler(indicator, signal.SIGUSR2)
@@ -367,7 +368,6 @@ if __name__ == "__main__":
         os.kill(pid, (args.kill and signal.SIGKILL) or (args.refresh and    \
             signal.SIGUSR2) or signal.SIGUSR1)
     elif not (args.kill or args.refresh):
-        if args.no_daemon: main()   # run
-        else: os.system(sys.argv[0]+' --no-daemon &') # start another & quit
+        main()   # run
 
     sys.exit(0)

--- a/indicator-stickynotes.py
+++ b/indicator-stickynotes.py
@@ -335,7 +335,7 @@ if __name__ == "__main__":
             help="kill background proccess")
     parser.add_argument("-r","--refresh", action="store_true",
             help="refresh data")
-    parser.add_argument("-c","--category", nargs=1, default='',
+    parser.add_argument("-c","--category", nargs=1, default=[''],
             help="using with [-n|-i ...], set categeory", type=str)
     parser.add_argument("-i","--infile", type=argparse.FileType('r'),
             help="new sticky note with content from a file")

--- a/stickynotes/backend.py
+++ b/stickynotes/backend.py
@@ -147,12 +147,15 @@ class NoteSet:
             if "uuid" in newnote and newnote["uuid"] in dnotes:
                 # Update notes that are already in the noteset
                 orignote = dnotes[newnote["uuid"]]
-                if "body" in newnote:
-                    orignote.body = newnote["body"]
-                if "properties" in newnote:
-                    orignote.properties = newnote["properties"]
-                if "cat" in newnote:
-                    orignote.category = newnote["cat"]
+                # make sure it's an 'Update'
+                if datetime.strptime(newnote["last_modified"],      \
+                        "%Y-%m-%dT%H:%M:%S") > orignote.last_modified:
+                    if "body" in newnote:
+                        orignote.body = newnote["body"]
+                    if "properties" in newnote:
+                        orignote.properties = newnote["properties"]
+                    if "cat" in newnote:
+                        orignote.category = newnote["cat"]
             else:
                 # otherwise create a new note
                 if "uuid" in newnote:

--- a/stickynotes/backend.py
+++ b/stickynotes/backend.py
@@ -165,12 +165,29 @@ class NoteSet:
         self.notes = list(dnotes.values())
         self.showall(reload_from_backend=True)
 
-    def new(self):
+    def find_category(self, name=""):
+        # return cid of the first matched category
+        if name:
+            try: cid = (cat for cat in self.categories if \
+                    self.categories[cat]["name"] == name).__next__()
+            # not found
+            except Exception: cid = None
+        else:
+            cid = None
+        return cid
+
+    def new(self, notebody='', category=''):
         """Creates a new note and adds it to the note set"""
+        cid = self.find_category(name=category)
+        if category and not cid:
+            cid = str(uuid.uuid4())
+            self.categories[cid]={'name':category}
         note = Note(gui_class=self.gui_class, noteset=self,
-                category=self.properties.get("default_cat", ""))
+                category=cid)
+        note.body=notebody
+        note.set_locked_state(not not notebody)
         self.notes.append(note)
-        note.show()
+        self.gui_class and note.show()      # show if created with gui
         return note
 
     def showall(self, *args, **kwargs):

--- a/stickynotes/gui.py
+++ b/stickynotes/gui.py
@@ -359,13 +359,15 @@ class StickyNote:
         return False
 
     def delete(self, *args):
-        winConfirm = Gtk.MessageDialog(self.winMain, None,
-                Gtk.MessageType.QUESTION, Gtk.ButtonsType.NONE,
-                _("Are you sure you want to delete this note?"))
-        winConfirm.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.REJECT,
-                Gtk.STOCK_DELETE, Gtk.ResponseType.ACCEPT)
-        confirm = winConfirm.run()
-        winConfirm.destroy()
+        if self.bbody.get_char_count(): # ask for only non-empty notes
+            winConfirm = Gtk.MessageDialog(self.winMain, None,
+                    Gtk.MessageType.QUESTION, Gtk.ButtonsType.NONE,
+                    _("Are you sure you want to delete this note?"))
+            winConfirm.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.REJECT,
+                    Gtk.STOCK_DELETE, Gtk.ResponseType.ACCEPT)
+            confirm = winConfirm.run()
+            winConfirm.destroy()
+        else: confirm = Gtk.ResponseType.ACCEPT
         if confirm == Gtk.ResponseType.ACCEPT:
             self.note.delete()
             self.winMain.destroy()


### PR DESCRIPTION
Here are new features this PR supposed to bring:
- Running in the background by default.
- No confirmations when deleting empty notes.
- Bunch of command line arguments:
  - `-k` to kill a background process;
  - `-r` to send an `USR-2` signal to the existing process, and it will reload the notes. (the feature "no arguments to show all" remained);
  - `-i` to create new note from file;
  - `-n` to create new note from strings, escaped characters should be decoded;
  - `-c` to set category when creating new note, (absence for default category, creating new categories if not existing)
  - `--no-daemon` to run in the foreground.
  
  `-r` and `-k` work only for existing process; `-c` works only when creating new notes; `-i` and `-n` create new notes but don't start new process, then send an `USR-2` signal to the existing one (if any).

With this interface users should be able to create shell scripts that can launch notes automatically. However it may also be dangerous for scripts with unexpected designs, like infinite loops and improper input files, that can cause some chaos...
